### PR TITLE
Fixing incorrect change to honesty and making tree options a const reference.

### DIFF
--- a/core/src/forest/ForestTrainer.cpp
+++ b/core/src/forest/ForestTrainer.cpp
@@ -40,7 +40,7 @@ const Forest ForestTrainer::train(Data* data,
   uint num_trees = options.get_num_trees();
 
   // Ensure that the sample fraction is not too small and honesty fraction is not too extreme.
-  TreeOptions tree_options = options.get_tree_options();
+  const TreeOptions& tree_options = options.get_tree_options();
   bool honesty = tree_options.get_honesty();
   double honesty_fraction = tree_options.get_honesty_fraction();
   if ((size_t) num_samples * options.get_sample_fraction() < 1) {

--- a/r-package/grf/R/causal_forest.R
+++ b/r-package/grf/R/causal_forest.R
@@ -153,8 +153,8 @@ causal_forest <- function(X, Y, W,
 
     if (is.null(W.hat)) {
       forest.W <- regression_forest(X, W, sample.fraction = sample.fraction, mtry = mtry, tune.parameters = tune.parameters,
-                                    num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = honesty,
-                                    honesty.fraction = honesty.fraction, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
+                                    num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = TRUE,
+                                    honesty.fraction = NULL, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
                                     clusters = clusters, samples_per_cluster = samples_per_cluster);
       W.hat <- predict(forest.W)$predictions
     } else if (length(W.hat) == 1) {

--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -93,8 +93,8 @@ instrumental_forest <- function(X, Y, W, Z,
     
     if (is.null(Y.hat)) {
       forest.Y <- regression_forest(X, Y, sample.fraction = sample.fraction, mtry = mtry, 
-                                    num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = honesty,
-                                    honesty.fraction = honesty.fraction, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
+                                    num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = TRUE,
+                                    honesty.fraction = NULL, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
                                     clusters = clusters, samples_per_cluster = samples_per_cluster);
       Y.hat <- predict(forest.Y)$predictions
     } else if (length(Y.hat) == 1) {
@@ -105,8 +105,8 @@ instrumental_forest <- function(X, Y, W, Z,
     
     if (is.null(W.hat)) {
       forest.W <- regression_forest(X, W, sample.fraction = sample.fraction, mtry = mtry, 
-                                    num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = honesty,
-                                    honesty.fraction = honesty.fraction, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
+                                    num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = TRUE,
+                                    honesty.fraction = NULL, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
                                     clusters = clusters, samples_per_cluster = samples_per_cluster);
       W.hat <- predict(forest.W)$predictions
     } else if (length(W.hat) == 1) {
@@ -117,8 +117,8 @@ instrumental_forest <- function(X, Y, W, Z,
     
     if (is.null(Z.hat)) {
       forest.Z <- regression_forest(X, Z, sample.fraction = sample.fraction, mtry = mtry, 
-                                    num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = honesty,
-                                    honesty.fraction = honesty.fraction, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
+                                    num.trees = min(500, num.trees), num.threads = num.threads, min.node.size = NULL, honesty = TRUE,
+                                    honesty.fraction = NULL, seed = seed, ci.group.size = 1, alpha = alpha, imbalance.penalty = imbalance.penalty,
                                     clusters = clusters, samples_per_cluster = samples_per_cluster);
       Z.hat <- predict(forest.Z)$predictions
     } else if (length(Z.hat) == 1) {


### PR DESCRIPTION
Merging these two changes based on Julie's comments on pull request #297 from swager/grf. Honesty = honesty became honesty = TRUE in 4 places across 2 files. This represents a reversal of my earlier incorrect change. Tree options access is now a const reference in ForestTrainer.cpp.